### PR TITLE
Initial meson support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 # Our project programs.
 /tmpfiles
 /tmpfiles_test
+
+# Meson
+builddir/
+subprojects/*/

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,31 @@
+project('opentmpfiles', ['c', 'cpp'],
+  version : '0.1',
+  default_options : ['warning_level=3'])
+
+
+## Build libtmpfiles ##
+libtmpfiles_src = [
+  'src/set.c'
+]
+
+tmpfileslib = library('tmpfiles',
+                      libtmpfiles_src,
+                      version : meson.project_version(),
+                      install : true)
+
+libtmpfiles_dep = declare_dependency(
+  link_with : tmpfileslib
+)
+
+## Build opentmpfiles ##
+src = [
+  'src/cli.c',
+  'src/main.c',
+]
+
+executable('opentmpfiles',
+           src,
+           dependencies : libtmpfiles_dep,
+           install : true)
+
+subdir('test')

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,10 @@
+[wrap-file]
+directory = googletest-release-1.8.1
+
+source_url = https://github.com/google/googletest/archive/release-1.8.1.zip
+source_filename = gtest-1.8.1.zip
+source_hash = 927827c183d01734cc5cfef85e0ff3f5a92ffe6188e0d18e909c5efebf28a0c7
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/gtest/1.8.1/1/get_zip
+patch_filename = gtest-1.8.1-1-wrap.zip
+patch_hash = f79f5fd46e09507b3f2e09a51ea6eb20020effe543335f5aee59f30cc8d15805

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,15 @@
+test_src = [
+  'cli_test.cc',
+  'set_test.cc',
+  'xfuncs_test.cc'
+]
+
+inc = include_directories('../src')
+
+gtest_dep = dependency('gtest', main : true, fallback : ['gtest', 'gtest_main_dep'])
+
+e = executable('tmpfiles_test',
+               test_src,
+               include_directories : inc,
+               dependencies : [gtest_dep, libtmpfiles_dep])
+test('test', e)


### PR DESCRIPTION
How to build:
```
# Let meson generate the makefiles
meson builddir
# Invoke ninja to build everything
ninja -C builddir
# Install the files into e.g. /tmp/install
# The prefix can be set in the first meson command with e.g. "-Dprefix=/usr" in the first command
# You can configure an existing builddir by using the "meson configure" command
env DESTDIR=/tmp/install ninja -C builddir install
# You can run the test(s) with:
meson test -C builddir/
# You can of course cd into builddir and leave out the directory for most of those commands
```
The results:
```
/tmp/install/usr/local/bin/:
totalo 28
drwxr-xr-x 2 luca luca    60 Okt 23 19:15 ./
drwxr-xr-x 4 luca luca    80 Okt 23 19:15 ../
-rwxr-xr-x 1 luca luca 24800 Okt 23 19:15 opentmpfiles*

/tmp/install/usr/local/lib/:
totalo 20
drwxr-xr-x 2 luca luca   100 Okt 23 19:15 ./
drwxr-xr-x 4 luca luca    80 Okt 23 19:15 ../
lrwxrwxrwx 1 luca luca    16 Okt 23 19:15 libtmpfiles.so -> libtmpfiles.so.0*
lrwxrwxrwx 1 luca luca    18 Okt 23 19:15 libtmpfiles.so.0 -> libtmpfiles.so.0.1*
-rwxr-xr-x 1 luca luca 20232 Okt 23 19:14 libtmpfiles.so.0.1*
```
I've also set up, that for people who don't have gtest installed, it will be automatically downloaded and used through [meson wrapdb](https://mesonbuild.com/Using-wraptool.html), but if gtest is already installed, that will be used.

If you have any questions, feel free to ask :)